### PR TITLE
Align installer with the latest changes in macOS compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 
 macos-rtools.pkg
+.Rproj.user
+.Rhistory
+*gfortran*.pkg
+*clang*.pkg

--- a/README.md
+++ b/README.md
@@ -6,17 +6,14 @@ that contains binaries used to create the CRAN official macOS _R_ binary.
 Specifically, the installer will try to download and install:
 
 - Xcode command line tools (XCode CLI) from Apple
-- `clang4` from <http://r.research.att.com/libs/>
-- `gfortran` from <https://gcc.gnu.org/wiki/GFortranBinaries#MacOS-1>
+- `clang7` from <https://cran.r-project.org/bin/macosx/tools/>
+- `gfortran6.1` from <https://cran.r-project.org/bin/macosx/tools/>
 
 For those interested, the installer can be obtained
 on either the project's [**release page**](https://github.com/coatless/r-macos-rtools/releases/latest)
 or through <http://go.illinois.edu/r-macos-rtools-pkg>. The pre-built binaries this
 installer encloses can be found at <https://developer.apple.com/download/more/>,
-<http://r.research.att.com/libs/>, and <https://gcc.gnu.org/wiki/GFortranBinaries#MacOS-1>. 
-Unlike the [previous installer](https://github.com/coatless/r-macos-clang), 
-which only installed `clang4`, this installer requires internet access
-to work.
+<https://cran.r-project.org/bin/macosx/tools/>, and <https://gcc.gnu.org/wiki/GFortranBinaries#MacOS-1>. 
 
 **Note** The installer package was developed by [James Joseph Balamuta](https://thecoatlessprofessor.com)
 and has no connection with the R project’s macOS CRAN maintainers. 
@@ -44,11 +41,11 @@ The macOS _R_ toolchain installer performs four actions that require
 the user's password to accomplish. These actions are:
 
 1. download and install XCode CLI via secure Apple product update
-1. download, verify, and install the `clang4` pre-made binary 
-   files into the `/usr/local/clang4` directory
-1. download, verify, and install `gfortran`
-1. establish the proper paths for `CC`, `CXX`, `CXX**`, `FLIBS`,
-    and `LDFLAGS` in the  `~/.R/Makevars` file
+1. download, verify, and install the `clang7` pre-made binary 
+   files into the `/usr/local/clang7` directory
+1. download, verify, and install `gfortran6.1`
+1. establish the proper header files in `CFLAGS`, `CPPFLAGS`, and `CXXFLAGS` in the `~/.R/Makevars` file
+1. add to the `PATH` variable where the `clang7` binary is by using `~/.Renviron`
 
 Verify steps are conducted using embedded md5 hashes of the files.
 If the hash is not identical to what was embedded, the installer will
@@ -57,9 +54,6 @@ exit. For details as to how this implemented please see
 and the 
 [Pull Request 10: Feature Pkg Hash Verification](https://github.com/coatless/r-macos-rtools/pull/10).
 
-In essence, it provides a graphical user interface installation guide,
-more secure path manipulation, and a smarter handling of a pre-existing
-`~/.R/Makevars` when compared to a pure bash approach.
 
 ## Verify the Installer
 
@@ -87,19 +81,16 @@ Below is an abridged version of the actions of each file provided.
 	    by using a [headless cli check](https://github.com/timsutton/osx-vm-templates/blob/ce8df8a7468faa7c5312444ece1b977c1b2f77a4/scripts/xcode-cli-tools.sh#L8-L14),
 		downloads the installer from <https://developer.apple.com/download/more/>,
 		and installs it using `softwareupdate`.
-      - Downloads the `clang-4.0.0-darwin15.6-Release.tar.gz` from
-       <http://r.research.att.com/libs/> and extracts it into `/` directory 
+      - Downloads the `clang-7.0.0.pkg` from
+       <https://cran.r-project.org/bin/macosx/tools/> and installs it into `/` directory
 	    so that it is installed on `/usr/local/clang4`
-      - Detects the appropriate gfortran binary (either 6.1 or 6.3) from
-        <https://gcc.gnu.org/wiki/GFortranBinaries#MacOS-1>, 
-		downloads it from <http://coudert.name/software/>, and
-		installs it into `/usr/local/gfortran`
-   - Create or modify the `~/.R/Makevars` file with the necessary implicit variables
-     to compile.
-	   - `CC`, `CXX`, `CXX**`, and `LDFLAGS` for `clang4`
-	   - `FLIBS` if on macOS Sierra / High Sierra (10.12 - 10.13) to avoid
-	     a headache.
-   - This is run at the _end_ of the installer routine.
+      - Downloads the gfortran binary 6.1 from 
+        <https://cran.r-project.org/bin/macosx/tools/gfortran-6.1.pkg>, and 
+        and installs it into `/usr/local/gfortran`.
+   - Create the `~/.R/Makevars` file with the necessary implicit variables
+     to compile using the new header location.
+	   - `CFLAGS`, `CPPFLAGS`, `CXXFLAGS` for `clang7`
+   - Make the `~/.Renviron` file with a modified `PATH` variable to the location of `clang7`.
 - `make_installer.sh`
    - Create the installer package R binary installer `.pkg`
       - Builds the package from the extracted tar using `pkgbuild` 

--- a/build_files/WELCOME_DISPLAY.rtf
+++ b/build_files/WELCOME_DISPLAY.rtf
@@ -1,4 +1,4 @@
-{\rtf1\ansi\ansicpg1252\cocoartf1561\cocoasubrtf200
+{\rtf1\ansi\ansicpg1252\cocoartf1671\cocoasubrtf600
 {\fonttbl\f0\fmodern\fcharset0 Courier;\f1\fmodern\fcharset0 Courier-Bold;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
@@ -16,11 +16,11 @@ Welcome to the
 \pard\tx220\tx720\pardeftab720\li720\fi-720\sl280\partightenfactor0
 \ls1\ilvl0\cf0 \kerning1\expnd0\expndtw0 {\listtext	1.	}Install the {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/library/content/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-WHAT_IS_THE_COMMAND_LINE_TOOLS_PACKAGE_"}}{\fldrslt Xcode Command Line Tools}} provided by {\field{\*\fldinst{HYPERLINK "https://developer.apple.com/download/more/"}}{\fldrslt Apple}}.\
 {\listtext	2.	}\expnd0\expndtw0\kerning0
-Install the {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#macOS"}}{\fldrslt clang4 binaries}} provided by {\field{\*\fldinst{HYPERLINK "https://r.research.att.com/libs"}}{\fldrslt CRAN}}.\
-\ls1\ilvl0\kerning1\expnd0\expndtw0 {\listtext	3.	}Install {\field{\*\fldinst{HYPERLINK "https://gcc.gnu.org/wiki/GFortranBinaries#MacOS-1"}}{\fldrslt gfortran binaries}} provided by {\field{\*\fldinst{HYPERLINK "https://gcc.gnu.org/wiki/HomePage"}}{\fldrslt GNU\'92s GCC Project}}.\expnd0\expndtw0\kerning0
+Install the {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/doc/manuals/r-patched/R-admin.html#macOS"}}{\fldrslt clang7 binaries}} provided by {\field{\*\fldinst{HYPERLINK "https://r.research.att.com/libs"}}{\fldrslt CRAN}}.\
+\ls1\ilvl0\kerning1\expnd0\expndtw0 {\listtext	3.	}Install {\field{\*\fldinst{HYPERLINK "https://gcc.gnu.org/wiki/GFortranBinaries#MacOS-1"}}{\fldrslt gfortran6.1 binaries}} provided by {\field{\*\fldinst{HYPERLINK "https://gcc.gnu.org/wiki/HomePage"}}{\fldrslt GNU\'92s GCC Project}}.\expnd0\expndtw0\kerning0
 \
 \ls1\ilvl0\kerning1\expnd0\expndtw0 {\listtext	4.	}\expnd0\expndtw0\kerning0
-Create and/or populate {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/doc/manuals/R-exts.html#Using-Makevars"}}{\fldrslt ~/.R/Makevars}} with the {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/bin/macosx/tools/"}}{\fldrslt appropriate paths}}.\
+Create and populate {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/doc/manuals/R-exts.html#Using-Makevars"}}{\fldrslt ~/.R/Makevars}} with the appropriate paths.\
 \pard\tx720\pardeftab720\sl280\partightenfactor0
 \cf0 \
 \pard\pardeftab720\sl280\partightenfactor0
@@ -28,8 +28,5 @@ Create and/or populate {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/
 \f1\b \cf0 Note:
 \f0\b0  The installer package was developed by {\field{\*\fldinst{HYPERLINK "https://thecoatlessprofessor.com/"}}{\fldrslt James Joseph Balamuta}} and has no connection with the R project\'92s macOS CRAN maintainers. Financial support was provided to sign the installer by {\field{\*\fldinst{HYPERLINK "http://www.ed.ac.uk/profile/timothy-bates"}}{\fldrslt Professor Timothy Bates}} of the {\field{\*\fldinst{HYPERLINK "http://www.ed.ac.uk/"}}{\fldrslt University of Edinburgh}}. \
 \
-Design Implementation: \
-\pard\pardeftab720\sl280\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://thecoatlessprofessor.com/programming/tools/macos-r-clang4-binary-installer"}}{\fldrslt \cf0 https://thecoatlessprofessor.com/programming/creating-macos-rtools}}\
-Installer Source code: {\field{\*\fldinst{HYPERLINK "https://github.com/coatless/r-macos-rtools"}}{\fldrslt https://github.com/coatless/r-macos-rtools}}\
+Installer Source code: {\field{\*\fldinst{HYPERLINK "https://github.com/rmacoslib/r-macos-rtools"}}{\fldrslt https://github.com/rmacoslib/r-macos-rtools}}\
 }

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -30,10 +30,12 @@ chmod a+x scripts/*
 # Version of installer
 INSTALLER_VERSION=1.1.0
 
-# Create a payload-free package
+# Previously, we created a payload-free package due to downloading
+# components as needed. We used a read receipt trick of including an empty
+# directory for this purpose.
 
-# Generally, this means --nopayload, but I want a receipt
-# So, we have to include an empty directory
+# Now, we're aiming to create a payload package with pre-defined components.
+# In particular, we merge together clang 7.0.0 and gfortran 6.1
 mkdir empty
 
 # Build macOS installer

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -3,9 +3,9 @@
 #
 # make_installer.sh
 #
-# Copyright (C) 2018 James Joseph Balamuta <balamut2@illinois.edu>
+# Copyright (C) 2018 - 2019 James Joseph Balamuta <balamut2@illinois.edu>
 #
-# Version 1.1.0 -- 06/06/18
+# Version 3.0.0 -- 09/13/19
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -28,7 +28,7 @@
 chmod a+x scripts/*
 
 # Version of installer
-INSTALLER_VERSION=1.1.0
+INSTALLER_VERSION=3.0.0
 
 # Previously, we created a payload-free package due to downloading
 # components as needed. We used a read receipt trick of including an empty

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -90,7 +90,7 @@ END
 # Write the standard to the distribution file.
 add_line_1before_last "${MINVERSION}" distribution.xml
 
-echo "Rebuilding the package archive..."
+echo "[status] Rebuilding the package archive..."
 
 # Rebuild package with distribution hacks
 productbuild --distribution distribution.xml \

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -75,6 +75,19 @@ add_line_1before_last '<welcome file="WELCOME_DISPLAY.rtf"/>' distribution.xml
 # Add a license file for LLVM
 add_line_1before_last '<license file="LICENSE.rtf"/>' distribution.xml
 
+# Enforce a minimum standard for the installer.
+# R CRAN Binaries use OS X Mavericks 10.11
+# Docs: https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Distribution_XML_Ref.html#//apple_ref/doc/uid/TP40005370-CH100-SW33
+MINVERSION=$(cat <<-END
+<allowed-os-versions>
+    <os-version min="10.11.0" />
+</allowed-os-versions>
+END
+)
+
+# Write the standard to the distribution file.
+add_line_1before_last "${MINVERSION}" distribution.xml
+
 echo "Rebuilding the package archive..."
 
 # Rebuild package with distribution hacks

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -139,7 +139,7 @@ remove_config_variable(){
 		# Remove matches
 		# '' required due to macOS
 		sed -i '' "/$pattern/d" $config_file
-		echo "Removed configuration line containing: $pattern ..."
+		echo "[status] Removed configuration line containing: $pattern ..."
 	fi
 }
 
@@ -156,11 +156,11 @@ append_config_variable(){
 		# Append to the end of the line of each match
 		# '' required due to macOS
 		sed -i '' "\~$pattern~s~$~ $append_with~" $config_file
-		echo "Appended configuration line containing $pattern with $append_with ..."
+		echo "[status] Appended configuration line containing $pattern with $append_with ..."
 	else
 		# Append a new line to end of config file
 		echo "$pattern=$append_with" >> $config_file
-		echo "Added new configuration line $pattern=$append_with to end of $config_file..."
+		echo "[status] Added new configuration line $pattern=$append_with to end of $config_file..."
 	fi
 }
 
@@ -168,7 +168,7 @@ add_config_variable(){
 	config_var=$1
 	config_file=$2
 
-	echo "Adding configuration line $config_var to $config_file ..."
+	echo "[status] Adding configuration line $config_var to $config_file ..."
 
 	# Append a new line to end of config file
 	echo "$config_var" >> $config_file
@@ -204,7 +204,7 @@ CC_COMPILER=/usr/local/clang7/bin/clang
 # Location of CXX Compiler
 CXX_COMPILER=/usr/local/clang7/bin/clang++
 
-echo "Checking if file '~/.R/Makevars' exists"
+echo "[init] Checking if file '~/.R/Makevars' exists"
 if [ -f "$R_MAKEVARS_LOCAL" ]; then	
 
 	echo "'~/.R/Makevars' detected. Making a backup at ''~/.R/Makevars.bck'..."

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -192,8 +192,8 @@ download_file $LIBS_URL $REQUESTED_FILE
 # exit if this is not the case
 check_md5_hash $REQUESTED_FILE "cef3fd2a5c165d00f9941f64ea4024f7"
 
-# Extract file into root
-extract_file $REQUESTED_FILE
+# Install the package into root
+install_pkg_root $REQUESTED_FILE
 
 # Clean up by removing tar
 rm -rf $REQUESTED_FILE

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -122,6 +122,11 @@ check_md5_hash() {
     fi
 }
 
+# 1: Package to install 
+install_pkg_root() {
+	sudo installer -package $1 -target /
+}
+
 ################################################################
 
 # The following script are meant to modify the Makevars file

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -85,9 +85,9 @@ fi
 #2 File name
 download_file(){
 	if [ -f "$2" ]; then
-		echo "$2 has already been downloaded..."
+		echo "[note] $2 has already been downloaded..."
 	else 
-		echo "Downloading file $2 ... Please be patient..."	
+		echo "[status] Downloading file $2 ... Please be patient..."	
 		# Download file into working directory
 		curl -O $1$2
 	fi
@@ -115,6 +115,9 @@ check_md5_hash() {
     if [ "$FILE_HASH" = "$2" ]; then
        echo 0
     else 
+	   echo "[error] File does not match hash..."
+	   echo "[status] Hash 1: ${FILE_HASH} $2"
+	   echo "[status] Hash 2: $2"
        exit 1
     fi
 }

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -210,68 +210,44 @@ CLANG_BINARY=clang7
 CC_COMPILER=/usr/local/${CLANG_BINARY}/bin/clang
 
 # Location of CXX Compiler
-
-echo "[init] Checking if file '~/.R/Makevars' exists"
-if [ -f "$R_MAKEVARS_LOCAL" ]; then	
-
-	echo "'~/.R/Makevars' detected. Making a backup at ''~/.R/Makevars.bck'..."
-
-	# Consider adding [[:space:]]*= for a more selective destruction
-
-	remove_config_variable "CC" $R_MAKEVARS_LOCAL
-	add_config_variable "CC=$CC_COMPILER" $R_MAKEVARS_LOCAL
-
-	remove_config_variable "CXX" $R_MAKEVARS_LOCAL
-	add_config_variable "CXX=$CXX_COMPILER" $R_MAKEVARS_LOCAL
 CXX_COMPILER=/usr/local/${CLANG_BINARY}/bin/clang++
 
-	# Adds configuration variables that specify all C++ standards
+HEADER_LOCATION="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
 
-	add_config_variable "CXX1X=$CXX_COMPILER" $R_MAKEVARS_LOCAL
-
-	add_config_variable "CXX98=$CXX_COMPILER" $R_MAKEVARS_LOCAL
-	add_config_variable "CXX11=$CXX_COMPILER" $R_MAKEVARS_LOCAL
-	add_config_variable "CXX14=$CXX_COMPILER" $R_MAKEVARS_LOCAL
-	add_config_variable "CXX17=$CXX_COMPILER" $R_MAKEVARS_LOCAL
-
-	# Remove any instances of the LDFLAG (in the odd case they re-run the installer...)
-	LDFLAGS_PATH_VAR="-L/usr/local/clang4/lib"
-
-	sed -i '' "s~$LDFLAGS_PATH_VAR~~" $R_MAKEVARS_LOCAL
-
-	# Add only one instance 
-	append_config_variable "LDFLAGS" "$LDFLAGS_PATH_VAR" $R_MAKEVARS_LOCAL
-
+echo "[init] Checking if file '~/.R/Makevars' exists"
+if [ -f "${R_MAKEVARS_LOCAL}" ]; then	
+	echo "[setup] '~/.R/Makevars' detected. Making a backup at ''~/.R/Makevars.bck'..."
+	cp ${R_MAKEVARS_LOCAL} ${R_MAKEVARS_LOCAL}.bck
 else
-
-	echo "No '~/.R/Makevars' found. Creating one..."
-
-	# Create the R directory
+	echo "[setup] Creating '~/.R/' directory..."
 	mkdir -p ~/.R
+fi
 
-	# Create the file
-	touch $R_MAKEVARS_LOCAL
+echo "[init] Creating '~/.R/Makevars' from scratch..."
 
-	echo "Filling '~/.R/Makevars' with appropriate compile time implicit variables..."
+# Create the file
+touch ${R_MAKEVARS_LOCAL}
 
-	# Fill with appropriate linking statements via heredoc insertion
-	# The - removes tabbing
-	cat <<- EOF > $R_MAKEVARS_LOCAL
-	# The following statements are required to use the clang4 binary
-	CC=$CC_COMPILER
-	CXX=$CXX_COMPILER
-	CXX1X=$CXX_COMPILER
-	CXX98=$CXX_COMPILER
-	CXX11=$CXX_COMPILER
-	CXX14=$CXX_COMPILER
-	CXX17=$CXX_COMPILER
-	LDFLAGS=-L/usr/local/clang4/lib
-	# End clang4 inclusion statements
+echo "[setup] Filling '~/.R/Makevars' with appropriate compile time implicit variables..."
+# Fill with appropriate linking statements via heredoc insertion
+# The - removes tabbing
+cat <<- EOF > ${R_MAKEVARS_LOCAL}
+# clang: start
+CFLAGS=$HEADER_LOCATION
+CCFLAGS=$HEADER_LOCATION
+CXXFLAGS=$HEADER_LOCATION
+# clang: end
 EOF
+
+echo "[setup] Success! '~/.R/Makevars' has been configured correctly..."
+
+##########################################
+
+# Add clang to path in .Renviron
+
 
 fi
 
-echo "Success! '~/.R/Makevars' has been configured correctly..."
 
 ##########################################
 

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -262,39 +262,27 @@ EOF
 
 ##########################################
 
+
 # gfortran binary
 
 # Deploy only the 6.1 gfortran binary
-GFORTRAN_DMG=gfortran-6.1-ElCapitan
-GFORTRAN_PKG=gfortran-6.1-ElCapitan/gfortran
-GFORTRAN_HASH="457b59a6453069cf72dee9a4f9bf1b0a"
-GFORTRAN_GH_VERSION="6.1/"
+GFORTRAN_HASH="201026216e8b373d9cd2efc0cc474bb8"
 
 # Download software
 
 # Provide download information for clang4 binary
-LIBS_URL="https://github.com/fxcoudert/gfortran-for-macOS/releases/download/"
-REQUESTED_FILE=${GFORTRAN_DMG}.dmg
+LIBS_URL="https://cran.r-project.org/bin/macosx/tools/"
+REQUESTED_FILE="gfortran-6.1.pkg"
 
 # Download file into working directory
-download_file $LIBS_URL$GFORTRAN_GH_VERSION $REQUESTED_FILE
+download_file $LIBS_URL $REQUESTED_FILE
 
 # Check the hash matches the built-in hash
 # exit if this is not the case
 check_md5_hash $REQUESTED_FILE $GFORTRAN_HASH
 
-# Perform headless installation of gfortran
-# Steps based on
-# https://apple.stackexchange.com/questions/73926/is-there-a-command-to-install-a-dmg
-
-# Attach gfortran dmg
-sudo hdiutil attach ${GFORTRAN_DMG}.dmg
-
-# Trigger the installer to install into root (default)
-sudo installer -package /Volumes/${GFORTRAN_DMG}/${GFORTRAN_PKG}.pkg -target /
-
-# Clean up by detaching the installer
-sudo hdiutil detach /Volumes/${GFORTRAN_DMG} -force
+# Install the package into root
+install_pkg_root $REQUESTED_FILE
 
 # Delete the dmg file
 rm -rf ${GFORTRAN_DMG}.dmg

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -3,9 +3,9 @@
 #
 # postinstall.sh
 #
-# Copyright (C) 2018 James Joseph Balamuta <balamut2@illinois.edu>
+# Copyright (C) 2018 - 2019 James Joseph Balamuta <balamut2@illinois.edu>
 # 
-# Version 1.1 -- 06/06/18
+# Version 3.0 -- 09/13/19
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -177,15 +177,15 @@ add_config_variable(){
 ################################################################
 
 # Provide download information for clang4 binary
-LIBS_URL="http://r.research.att.com/libs/"
-REQUESTED_FILE="clang-4.0.0-darwin15.6-Release.tar.gz"
+LIBS_URL="https://cran.r-project.org/bin/macosx/tools/"
+REQUESTED_FILE="clang-7.0.0.pkg"
 
 # Download file into working directory
 download_file $LIBS_URL $REQUESTED_FILE
 
 # Check the hash matches the built-in hash
 # exit if this is not the case
-check_md5_hash $REQUESTED_FILE "2bec4fbae8d9caf6499c941ef9b87eae"
+check_md5_hash $REQUESTED_FILE "cef3fd2a5c165d00f9941f64ea4024f7"
 
 # Extract file into root
 extract_file $REQUESTED_FILE

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -23,12 +23,25 @@
 #
 
 
-# This file contains code that is MIT licensed by Timothy Sutton 2013 - 2014
-# The code used is given at:
+# The headless CLI install given in this file is 
+# licensed under the MIT license by Timothy Sutton 2013 - 2014
+# The unmodified code can be found at:
 # https://github.com/timsutton/osx-vm-templates/blob/ce8df8a7468faa7c5312444ece1b977c1b2f77a4/scripts/xcode-cli-tools.sh#L8-L14
 
+# Retrieve version string x.y.z,
+# x should be 10, y is the version, and z is the patch issued
+product_version=$(sw_vers -productVersion)
 
-echo "Verifying Xcode CLI is installed..."
+# Substitute periods with spaces
+os_vers=( ${product_version//./ } )
+
+#  Retrieve 
+os_vers_minor="${os_vers[1]}"
+
+# For more details on manipulations, c.f. 
+# https://superuser.com/a/1259034/429046
+
+echo "[init] Verifying Xcode CLI is installed..."
 
 # Check if the Xcode CLI tool directory exists.
 # See technical note: https://developer.apple.com/library/content/technotes/tn2339/_index.html#//apple_ref/doc/uid/DTS40014588-CH1-WHAT_IS_THE_COMMAND_LINE_TOOLS_PACKAGE_
@@ -38,8 +51,15 @@ echo "Verifying Xcode CLI is installed..."
 
 if [ ! -d "/Library/Developer/CommandLineTools" ]; then
 
+    echo "[setup] Installing Xcode CLI..."
+
 	# Create a temporary file for the header
 	touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+    # Reset the Xcode CLI path
+	if [[ ${os_vers_minor} -eq 14 ]]; then
+		sudo xcode-select --reset 
+	fi
 
 	# Figure out the correct Xcode CLI for the given mac OS
 	PROD=$(sudo softwareupdate -l |
@@ -50,10 +70,13 @@ if [ ! -d "/Library/Developer/CommandLineTools" ]; then
 
 	# Install Xcode CLI		 
 	sudo softwareupdate -i "$PROD" --verbose;
-
+	
+    # Clean up the script
 	rm -rf /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+
+    echo "[note] Xcode CLI has been installed..."
 else
-	echo "Xcode CLI is installed..."	
+    echo "[note] Xcode CLI is already installed..."
 fi
 
 ################################################################

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -269,44 +269,20 @@ echo "Success! '~/.R/Makevars' has been configured correctly..."
 
 # gfortran binary
 
-## The following is based of a superuser answer by n8felton
-## https://superuser.com/a/1259034/429046
-
-# Retrieve version string 10.13.3
-product_version=$(sw_vers -productVersion)
-
-# Substitute periods with spaces
-os_vers=( ${product_version//./ } )
-
-#  Retrieve 
-os_vers_minor="${os_vers[1]}"
-
-# Check if the version is between Sierra or High Sierra. If not, check for El Capitan.
-if [[ ${os_vers_minor} -ge 12 && ${os_vers_minor} -le 13 ]]; then
-	GFORTRAN_DMG=gfortran-6.3-Sierra
-	GFORTRAN_PKG=gfortran
-	GFORTRAN_HASH="1849cea667bb714c5c04a8565a9fe231"
-
-	# Fill with appropriate linking statements via heredoc insertion
-	cat <<- EOF >> $R_MAKEVARS_LOCAL
-  # The following statement changes the Fortran linking path
-  FLIBS=-L/usr/local/gfortran/lib/gcc/x86_64-apple-darwin16/6.3.0
-  # End Fortran linking path statement
-EOF
-else
-	GFORTRAN_DMG=gfortran-6.1-ElCapitan
-	GFORTRAN_PKG=gfortran-6.1-ElCapitan/gfortran
-	GFORTRAN_HASH="457b59a6453069cf72dee9a4f9bf1b0a"
-fi
+# Deploy only the 6.1 gfortran binary
+GFORTRAN_DMG=gfortran-6.1-ElCapitan
+GFORTRAN_PKG=gfortran-6.1-ElCapitan/gfortran
+GFORTRAN_HASH="457b59a6453069cf72dee9a4f9bf1b0a"
+GFORTRAN_GH_VERSION="6.1/"
 
 # Download software
 
 # Provide download information for clang4 binary
-LIBS_URL="http://coudert.name/software/"
+LIBS_URL="https://github.com/fxcoudert/gfortran-for-macOS/releases/download/"
 REQUESTED_FILE=${GFORTRAN_DMG}.dmg
 
 # Download file into working directory
-download_file $LIBS_URL $REQUESTED_FILE
+download_file $LIBS_URL$GFORTRAN_GH_VERSION $REQUESTED_FILE
 
 # Check the hash matches the built-in hash
 # exit if this is not the case

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -199,10 +199,10 @@ rm -rf $REQUESTED_FILE
 R_MAKEVARS_LOCAL=~/.R/Makevars
 
 # Location of CC Compiler
-CC_COMPILER=/usr/local/clang4/bin/clang
+CC_COMPILER=/usr/local/clang7/bin/clang
 
 # Location of CXX Compiler
-CXX_COMPILER=/usr/local/clang4/bin/clang++
+CXX_COMPILER=/usr/local/clang7/bin/clang++
 
 echo "Checking if file '~/.R/Makevars' exists"
 if [ -f "$R_MAKEVARS_LOCAL" ]; then	

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -203,11 +203,13 @@ rm -rf $REQUESTED_FILE
 # Local User Makevars file
 R_MAKEVARS_LOCAL=~/.R/Makevars
 
+# clang compiler version
+CLANG_BINARY=clang7
+
 # Location of CC Compiler
-CC_COMPILER=/usr/local/clang7/bin/clang
+CC_COMPILER=/usr/local/${CLANG_BINARY}/bin/clang
 
 # Location of CXX Compiler
-CXX_COMPILER=/usr/local/clang7/bin/clang++
 
 echo "[init] Checking if file '~/.R/Makevars' exists"
 if [ -f "$R_MAKEVARS_LOCAL" ]; then	
@@ -221,6 +223,7 @@ if [ -f "$R_MAKEVARS_LOCAL" ]; then
 
 	remove_config_variable "CXX" $R_MAKEVARS_LOCAL
 	add_config_variable "CXX=$CXX_COMPILER" $R_MAKEVARS_LOCAL
+CXX_COMPILER=/usr/local/${CLANG_BINARY}/bin/clang++
 
 	# Adds configuration variables that specify all C++ standards
 

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -245,9 +245,20 @@ echo "[setup] Success! '~/.R/Makevars' has been configured correctly..."
 
 # Add clang to path in .Renviron
 
+# Establish the location for the R environment file
+R_ENVIRON_LOCAL=~/.Renviron
 
+echo "[init] Checking if file '~/.Renviron' exists"
+if [ -f "${R_ENVIRON_LOCAL}" ]; then	
+	echo "[setup] '~/.Renviron' detected. Making a backup at ''~/.Renviron.bck'..."
+	cp ${R_ENVIRON_LOCAL} ${R_ENVIRON_LOCAL}.bck
 fi
 
+cat <<- EOF > ${R_ENVIRON_LOCAL}
+# clang: start
+PATH="/usr/local/${CLANG_BINARY}/bin:\${PATH}"
+# clang: end
+EOF
 
 ##########################################
 


### PR DESCRIPTION
Notable:

- Use `~/.Renviron` to setup a `PATH` variable to compiler.
- Deploy `*FLAGS` in `~/.R/Makevars` to successfully handle the Xcode CLI changeover
- Depend on the CRAN variants for installer packages
- Add in a statement to reset the Xcode CLI environment. 

Closes #12, Close #14,  Close #15, Close #17, Close #18.
