### PR TITLE
Configuration file fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+* __v3.2.0__ - 2019-12-03
+
+- Fix issue where either `~/.R/Makevars` or `~/.Renviron` were owned by `root` instead of the user. (reported in #28 by @Ptterz!)
+- Change `README.md` and package installer splash screen to be explicit with what happens to pre-existing `~/.R/Makevars` and `~/.Renviron`. (reported in #27 by @joranE)
+
 * __v3.1.0__ - 2019-11-13
 
 - Add `CXXFLAGS` in `~/.R/Makevars` for better support prior to R 3.6.1

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Specifically, the installer will try to download and install:
 - `clang7` from <https://cran.r-project.org/bin/macosx/tools/>
 - `gfortran6.1` from <https://cran.r-project.org/bin/macosx/tools/>
 
+Aftwards, it will attempt to configure the necessary `~/.R/Makevars` and `~/.Renviron` files.
+If either file is pre-existing, then a backup will be made prior to setting up the new versions. 
+
 For those interested, the installer can be obtained
 on either the project's [**release page**](https://github.com/rmacoslib/r-macos-rtools/releases/latest)
 or through <http://go.illinois.edu/r-macos-rtools-pkg>. The pre-built binaries this
@@ -46,6 +49,10 @@ the user's password to accomplish. These actions are:
 1. download, verify, and install `gfortran6.1`
 1. establish the proper header files in `CFLAGS`, `CPPFLAGS`, and `CXXFLAGS` in the `~/.R/Makevars` file
 1. add to the `PATH` variable where the `clang7` binary is by using `~/.Renviron`
+
+**Note:** The installer will replace existing `~/.R/Makevars` and `~/.Renviron` files. 
+The existing files will be copied to a backup file, e.g. `~/.R/Makevars.bck` and `~/.Renvion.bck`.
+Re-running the installer _will_ result in the old backup files being wiped.
 
 Verify steps are conducted using embedded md5 hashes of the files.
 If the hash is not identical to what was embedded, the installer will
@@ -91,6 +98,7 @@ Below is an abridged version of the actions of each file provided.
      to compile using the new header location.
 	   - `CFLAGS`, `CPPFLAGS`, `CXXFLAGS` for `clang7`
    - Make the `~/.Renviron` file with a modified `PATH` variable to the location of `clang7`.
+   - **Note:** Pre-existing `~/.R/Makevars` and `~/.Renviron` files will be backed up prior to being overridden. 
 - `make_installer.sh`
    - Create the installer package R binary installer `.pkg`
       - Builds the package from the extracted tar using `pkgbuild` 

--- a/build_files/WELCOME_DISPLAY.rtf
+++ b/build_files/WELCOME_DISPLAY.rtf
@@ -2,7 +2,7 @@
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fmodern\fcharset0 Courier;\f1\fmodern\fcharset0 Courier-Bold;}
 {\colortbl;\red255\green255\blue255;}
 {\*\expandedcolortbl;;}
-{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listname ;}\listid1}}
+{\*\listtable{\list\listtemplateid1\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{decimal\}.}{\leveltext\leveltemplateid1\'02\'00.;}{\levelnumbers\'01;}\fi-360\li720\lin720 }{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{hyphen\}}{\leveltext\leveltemplateid2\'01\uc0\u8259 ;}{\levelnumbers;}\fi-360\li1440\lin1440 }{\listname ;}\listid1}}
 {\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}}
 \margl1440\margr1440\vieww14620\viewh8400\viewkind0
 \deftab720
@@ -21,6 +21,9 @@ Install the {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/doc/manuals
 \
 \ls1\ilvl0\kerning1\expnd0\expndtw0 {\listtext	4.	}\expnd0\expndtw0\kerning0
 Create and populate {\field{\*\fldinst{HYPERLINK "https://cran.r-project.org/doc/manuals/R-exts.html#Using-Makevars"}}{\fldrslt ~/.R/Makevars}} and ~/.Renviron with the appropriate paths.\
+\pard\tx940\tx1440\pardeftab720\li1440\fi-1440\sl280\partightenfactor0
+\ls1\ilvl1\cf0 \kerning1\expnd0\expndtw0 {\listtext	\uc0\u8259 	}If any file is pre-existing, they will be copied with `.bck` extension. \expnd0\expndtw0\kerning0
+\
 \pard\tx720\pardeftab720\sl280\partightenfactor0
 \cf0 \
 \pard\pardeftab720\sl280\partightenfactor0

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -5,7 +5,7 @@
 #
 # Copyright (C) 2018 - 2019 James Joseph Balamuta <balamut2@illinois.edu>
 #
-# Version 3.1.0 -- 2019-11-13
+# Version 3.2.0 -- 2019-12-03
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ echo "[setup] Creating an environment for the installer..."
 chmod a+x scripts/*
 
 # Version of installer
-INSTALLER_VERSION=3.1.0
+INSTALLER_VERSION=3.2.0
 
 # Previously, we created a payload-free package due to downloading
 # components as needed. We used a read receipt trick of including an empty

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -5,7 +5,7 @@
 #
 # Copyright (C) 2018 - 2019 James Joseph Balamuta <balamut2@illinois.edu>
 # 
-# Version 3.1.0 -- 2019-11-13
+# Version 3.2.0 -- 2019-12-03
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -243,6 +243,8 @@ HEADER_LOCATION="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
 
 echo "[init] Checking if file '~/.R/Makevars' exists"
 if [ -f "${R_MAKEVARS_LOCAL}" ]; then	
+	echo "[setup] Ensuring the existing '~/.R/Makevars' is writable ..."
+	sudo chown ${USER} ${R_MAKEVARS_LOCAL}
 	echo "[setup] '~/.R/Makevars' detected. Making a backup at ''~/.R/Makevars.bck' ..."
 	cp ${R_MAKEVARS_LOCAL} ${R_MAKEVARS_LOCAL}.bck
 else
@@ -280,7 +282,9 @@ R_ENVIRON_LOCAL=~/.Renviron
 
 echo "[init] Checking if file '~/.Renviron' exists"
 
-if [ -f "${R_ENVIRON_LOCAL}" ]; then	
+if [ -f "${R_ENVIRON_LOCAL}" ]; then
+	echo "[setup] Ensuring the existing '~/.Renviron' is writable ..."
+	sudo chown ${USER} ${R_ENVIRON_LOCAL}
 	echo "[setup] '~/.Renviron' detected. Making a backup at ''~/.Renviron.bck'..."
 	cp ${R_ENVIRON_LOCAL} ${R_ENVIRON_LOCAL}.bck
 fi


### PR DESCRIPTION
- Fix issue where either `~/.R/Makevars` or `~/.Renviron` were owned by `root` instead of the user. (reported in #28 by @Ptterz!)
- Change `README.md` and package installer splash screen to be explicit with what happens to pre-existing `~/.R/Makevars` and `~/.Renviron`. (reported in #27 by @joranE)