### PR TITLE
More robust CLI detection on macOS Catalina

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,34 +1,40 @@
 # ChangeLog
 
+* __v3.2.2__ - 2019-12-30
+
+- Xcode CLI headless installation for macOS Catalina was made more robust ([#33](https://github.com/rmacoslib/r-macos-rtools/issues/33)). 
+- Improved code formatting in `postinstall` script.
+- Better documented alignment of GitHub issues with changes in the ChangeLog.
+
 * __v3.2.1__ - 2019-12-17
 
-- Provide a _C++14_ specific `SHLIB_CXX14LDFLAGS` to address issues arising with _Stan_.
+- Provide a _C++14_ specific `SHLIB_CXX14LDFLAGS` to address issues arising with _Stan_. ([#24](https://github.com/rmacoslib/r-macos-rtools/issues/24))
 
 * __v3.2.0__ - 2019-12-03
 
-- Fix issue where either `~/.R/Makevars` or `~/.Renviron` were owned by `root` instead of the user. (reported in #28 by @Ptterz!)
-- Change `README.md` and package installer splash screen to be explicit with what happens to pre-existing `~/.R/Makevars` and `~/.Renviron`. (reported in #27 by @joranE)
+- Fix issue where either `~/.R/Makevars` or `~/.Renviron` were owned by `root` instead of the user. ([#28](https://github.com/rmacoslib/r-macos-rtools/issues/28))
+- Change `README.md` and package installer splash screen to be explicit with what happens to pre-existing `~/.R/Makevars` and `~/.Renviron`. ([#27](https://github.com/rmacoslib/r-macos-rtools/issues/27))
 
 * __v3.1.0__ - 2019-11-13
 
 - Add `CXXFLAGS` in `~/.R/Makevars` for better support prior to R 3.6.1
 - Add `SHLIB_CXXLDFLAGS` in `~/.R/Makevars` to link to the R ABI
-  libraries instead of system. (h/t Sebastian from the [Stan Project](https://mc-stan.org)).
+  libraries instead of system. (h/t Sebastian Weber from the [Stan Project](https://mc-stan.org), [#22](https://github.com/rmacoslib/r-macos-rtools/issues/22)).
 - Update detection scheme for headless Xcode CLI download and installation for macOS Catalina.
 - Improved installer event logging.
 - Update `README.md` details on components and URLs.
 
 * __v3.0.0__ - 2019-09-13
 
-- Use `~/.Renviron` to setup a `PATH` variable to `clang7` compiler location.
+- Use `~/.Renviron` to setup a `PATH` variable to `clang7` compiler location. ([#12](https://github.com/rmacoslib/r-macos-rtools/issues/12))
 - Deploy `*FLAGS` in `~/.R/Makevars` to successfully handle the Xcode CLI changeover
 - Depend on the CRAN variants for installer packages
-- Add in a statement to reset the Xcode CLI environment.
+- Add in a statement to reset the Xcode CLI environment. ([#11](https://github.com/rmacoslib/r-macos-rtools/issues/11))
 
 * __1.1.0__ - 2018-06-06
 
-- Added md5 hash check to verify downloaded contents (#8)
-- Changed download links to point to projects GitHub Release Page (#1)
+- Added md5 hash check to verify downloaded contents ([#8](https://github.com/rmacoslib/r-macos-rtools/issues/8))
+- Changed download links to point to projects GitHub Release Page ([#1](https://github.com/rmacoslib/r-macos-rtools/issues/1))
 
 * __1.0.0__ - 2018-03-23
 

--- a/distribution.xml
+++ b/distribution.xml
@@ -11,7 +11,7 @@
     <choice id="com.rbinaries.rtools" visible="false">
         <pkg-ref id="com.rbinaries.rtools"/>
     </choice>
-    <pkg-ref id="com.rbinaries.rtools" version="3.2.1" onConclusion="none">macos-rtools-temp.pkg</pkg-ref>
+    <pkg-ref id="com.rbinaries.rtools" version="3.2.2" onConclusion="none">macos-rtools-temp.pkg</pkg-ref>
 	<title>macOS R toolchain</title>
 	<background file="Rlogo.png" mime-type="image/png" />
 	<welcome file="WELCOME_DISPLAY.rtf"/>

--- a/make_installer.sh
+++ b/make_installer.sh
@@ -5,7 +5,7 @@
 #
 # Copyright (C) 2018 - 2019 James Joseph Balamuta <balamut2@illinois.edu>
 #
-# Version 3.2.1 -- 2019-12-17
+# Version 3.2.2 -- 2019-12-30
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ echo "[setup] Creating an environment for the installer..."
 chmod a+x scripts/*
 
 # Version of installer
-INSTALLER_VERSION=3.2.1
+INSTALLER_VERSION=3.2.2
 
 # Previously, we created a payload-free package due to downloading
 # components as needed. We used a read receipt trick of including an empty

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -5,7 +5,7 @@
 #
 # Copyright (C) 2018 - 2019 James Joseph Balamuta <balamut2@illinois.edu>
 # 
-# Version 3.2.1 -- 2019-12-17
+# Version 3.2.2 -- 2019-12-30
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -65,22 +65,11 @@ if [ ! -d "/Library/Developer/CommandLineTools" ]; then
     echo "[note] Retrieving correct Xcode CLI..."
     
     # Figure out the correct Xcode CLI for the given mac OS
-    PROD=""
-    if [[ ${os_vers_minor} -ge 15 ]]; then
-        echo "[note] Retrieving Xcode CLI on Catalina (10.15) or higher OS..."
-        PROD=$(sudo softwareupdate -l |
-            grep "\*.*Command Line" |
-            head -n 1 | awk -F"*" '{print $2}' |
-            sed -e 's/^ * Label: //' |
-            tr -d '\n')
-    else
-        echo "[note] Retrieving Xcode CLI on Mojave (10.14) or lower OS..."
-        PROD=$(sudo softwareupdate -l |
-            grep "\*.*Command Line" |
-            tail -n 1 | awk -F"*" '{print $2}' |
-            sed -e 's/^ *//' |
-            tr -d '\n')
-    fi
+    PROD=$(sudo softwareupdate -l |
+           grep "\*.*Command Line" |
+           tail -n 1 | awk -F"*" '{print $2}' |
+           sed -e 's/^ *Label: //' -e 's/^ *//' |
+           tr -d '\n')
 
     echo "[setup] Installing Xcode CLI via softwareupdate..."
     # Install Xcode CLI         

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -53,42 +53,42 @@ if [ ! -d "/Library/Developer/CommandLineTools" ]; then
 
     echo "[setup] Begin install procedure for Xcode CLI..."
 
-	# Create a temporary file for the header
-	touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    # Create a temporary file for the header
+    touch /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 
     # Reset the Xcode CLI path
-	if [[ ${os_vers_minor} -ge 14 ]]; then
+    if [[ ${os_vers_minor} -ge 14 ]]; then
         echo "[note] Needed to reset Xcode CLI path..."
-		sudo xcode-select --reset 
-	fi
+        sudo xcode-select --reset 
+    fi
     
     echo "[note] Retrieving correct Xcode CLI..."
     
-	# Figure out the correct Xcode CLI for the given mac OS
+    # Figure out the correct Xcode CLI for the given mac OS
     PROD=""
-	if [[ ${os_vers_minor} -ge 15 ]]; then
+    if [[ ${os_vers_minor} -ge 15 ]]; then
         echo "[note] Retrieving Xcode CLI on Catalina (10.15) or higher OS..."
-    	PROD=$(sudo softwareupdate -l |
-    		grep "\*.*Command Line" |
-    		head -n 1 | awk -F"*" '{print $2}' |
-    		sed -e 's/^ * Label: //' |
-    		tr -d '\n')
+        PROD=$(sudo softwareupdate -l |
+            grep "\*.*Command Line" |
+            head -n 1 | awk -F"*" '{print $2}' |
+            sed -e 's/^ * Label: //' |
+            tr -d '\n')
     else
         echo "[note] Retrieving Xcode CLI on Mojave (10.14) or lower OS..."
-    	PROD=$(sudo softwareupdate -l |
-    		grep "\*.*Command Line" |
-    		tail -n 1 | awk -F"*" '{print $2}' |
-    		sed -e 's/^ *//' |
-    		tr -d '\n')
-	fi
+        PROD=$(sudo softwareupdate -l |
+            grep "\*.*Command Line" |
+            tail -n 1 | awk -F"*" '{print $2}' |
+            sed -e 's/^ *//' |
+            tr -d '\n')
+    fi
 
     echo "[setup] Installing Xcode CLI via softwareupdate..."
-	# Install Xcode CLI		 
-	sudo softwareupdate -i "$PROD" --verbose;
-	
+    # Install Xcode CLI         
+    sudo softwareupdate -i "$PROD" --verbose;
+    
     echo "[clean] Removing temporary file created..."
     # Clean up the script
-	rm -rf /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
+    rm -rf /tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 
     echo "[done] Xcode CLI has been installed..."
 else
@@ -100,19 +100,19 @@ fi
 #1 Base URL (with trailing /)
 #2 File name
 download_file(){
-	if [ -f "$2" ]; then
-		echo "[note] $2 has already been downloaded..."
-	else 
-		echo "[status] Downloading file $2 ... Please be patient..."	
-		# Download file into working directory
-		curl -O $1$2
-	fi
+    if [ -f "$2" ]; then
+        echo "[note] $2 has already been downloaded..."
+    else 
+        echo "[status] Downloading file $2 ... Please be patient..."    
+        # Download file into working directory
+        curl -O $1$2
+    fi
 }
 
 #1 File name
 extract_file(){
-	# Extract in working directory
-	tar fvxz $1 -C /
+    # Extract in working directory
+    tar fvxz $1 -C /
 }
 
 ################################################################
@@ -120,7 +120,7 @@ extract_file(){
 #1 Path to File
 #2 md5 Hash to Check Against
 check_md5_hash() {
-	
+    
     # Obtain file hash
     FILE_HASH=$(md5 $1 | awk '{print $4}')
     
@@ -131,16 +131,16 @@ check_md5_hash() {
     if [ "$FILE_HASH" = "$2" ]; then
        echo 0
     else 
-	   echo "[error] File does not match hash..."
-	   echo "[status] Hash 1: ${FILE_HASH} $2"
-	   echo "[status] Hash 2: $2"
+       echo "[error] File does not match hash..."
+       echo "[status] Hash 1: ${FILE_HASH} $2"
+       echo "[status] Hash 2: $2"
        exit 1
     fi
 }
 
 # 1: Package to install 
 install_pkg_root() {
-	sudo installer -package $1 -target /
+    sudo installer -package $1 -target /
 }
 
 ################################################################
@@ -152,47 +152,47 @@ install_pkg_root() {
 #2 Config file to search
 remove_config_variable(){
 
-	pattern=$1
-	config_file=$2
+    pattern=$1
+    config_file=$2
 
-	# Check if there are matches
-	if grep -q $pattern $config_file; then
-		# Remove matches
-		# '' required due to macOS
-		sed -i '' "/$pattern/d" $config_file
-		echo "[status] Removed configuration line containing: $pattern ..."
-	fi
+    # Check if there are matches
+    if grep -q $pattern $config_file; then
+        # Remove matches
+        # '' required due to macOS
+        sed -i '' "/$pattern/d" $config_file
+        echo "[status] Removed configuration line containing: $pattern ..."
+    fi
 }
 
 #1 Variable to find
 #2 Value to append
 #3 Config file to search
 append_config_variable(){
-	pattern=$1
-	append_with=$2
-	config_file=$3
+    pattern=$1
+    append_with=$2
+    config_file=$3
 
-	# Check if there are matches
-	if grep -q $pattern $config_file; then
-		# Append to the end of the line of each match
-		# '' required due to macOS
-		sed -i '' "\~$pattern~s~$~ $append_with~" $config_file
-		echo "[status] Appended configuration line containing $pattern with $append_with ..."
-	else
-		# Append a new line to end of config file
-		echo "$pattern=$append_with" >> $config_file
-		echo "[status] Added new configuration line $pattern=$append_with to end of $config_file..."
-	fi
+    # Check if there are matches
+    if grep -q $pattern $config_file; then
+        # Append to the end of the line of each match
+        # '' required due to macOS
+        sed -i '' "\~$pattern~s~$~ $append_with~" $config_file
+        echo "[status] Appended configuration line containing $pattern with $append_with ..."
+    else
+        # Append a new line to end of config file
+        echo "$pattern=$append_with" >> $config_file
+        echo "[status] Added new configuration line $pattern=$append_with to end of $config_file..."
+    fi
 }
 
 add_config_variable(){
-	config_var=$1
-	config_file=$2
+    config_var=$1
+    config_file=$2
 
-	echo "[status] Adding configuration line $config_var to $config_file ..."
+    echo "[status] Adding configuration line $config_var to $config_file ..."
 
-	# Append a new line to end of config file
-	echo "$config_var" >> $config_file
+    # Append a new line to end of config file
+    echo "$config_var" >> $config_file
 }
 
 ################################################################
@@ -242,14 +242,14 @@ CXX_COMPILER=/usr/local/${CLANG_BINARY}/bin/clang++
 HEADER_LOCATION="-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
 
 echo "[init] Checking if file '~/.R/Makevars' exists"
-if [ -f "${R_MAKEVARS_LOCAL}" ]; then	
-	echo "[setup] Ensuring the existing '~/.R/Makevars' is writable ..."
-	sudo chown ${USER} ${R_MAKEVARS_LOCAL}
-	echo "[setup] '~/.R/Makevars' detected. Making a backup at ''~/.R/Makevars.bck' ..."
-	cp ${R_MAKEVARS_LOCAL} ${R_MAKEVARS_LOCAL}.bck
+if [ -f "${R_MAKEVARS_LOCAL}" ]; then    
+    echo "[setup] Ensuring the existing '~/.R/Makevars' is writable ..."
+    sudo chown ${USER} ${R_MAKEVARS_LOCAL}
+    echo "[setup] '~/.R/Makevars' detected. Making a backup at ''~/.R/Makevars.bck' ..."
+    cp ${R_MAKEVARS_LOCAL} ${R_MAKEVARS_LOCAL}.bck
 else
-	echo "[setup] Creating '~/.R/' directory ..."
-	mkdir -p ~/.R
+    echo "[setup] Creating '~/.R/' directory ..."
+    mkdir -p ~/.R
 fi
 
 echo "[init] Creating '~/.R/Makevars' from scratch ..."
@@ -284,10 +284,10 @@ R_ENVIRON_LOCAL=~/.Renviron
 echo "[init] Checking if file '~/.Renviron' exists"
 
 if [ -f "${R_ENVIRON_LOCAL}" ]; then
-	echo "[setup] Ensuring the existing '~/.Renviron' is writable ..."
-	sudo chown ${USER} ${R_ENVIRON_LOCAL}
-	echo "[setup] '~/.Renviron' detected. Making a backup at ''~/.Renviron.bck'..."
-	cp ${R_ENVIRON_LOCAL} ${R_ENVIRON_LOCAL}.bck
+    echo "[setup] Ensuring the existing '~/.Renviron' is writable ..."
+    sudo chown ${USER} ${R_ENVIRON_LOCAL}
+    echo "[setup] '~/.Renviron' detected. Making a backup at ''~/.Renviron.bck'..."
+    cp ${R_ENVIRON_LOCAL} ${R_ENVIRON_LOCAL}.bck
 fi
 
 echo "[setup] Writing configuration to '~/.Renviron' ..."


### PR DESCRIPTION
- Xcode CLI headless installation for macOS Catalina was made more robust ([#33](https://github.com/rmacoslib/r-macos-rtools/issues/33)). 
- Improved code formatting in `postinstall` script.
- Better documented alignment of GitHub issues with changes in the ChangeLog.
